### PR TITLE
Suppression caractères supplémentaires + ?>

### DIFF
--- a/sf_pandora_tp1/src/Controller/AdditionController.php
+++ b/sf_pandora_tp1/src/Controller/AdditionController.php
@@ -54,5 +54,3 @@ class AdditionController extends AbstractController
     }
 }
 
-?>
-


### PR DESCRIPTION
La suppression de caractères excédentaires (espace après balise PHP) après le code serveur, sinon cela transmet de nouvelles entêtes HTTP, **empêchant l'initialisation de la session**
Le message est le suivant : 
`symfony failed to start session because headers have already sent by`

La balise PHP de fin a été supprimée, car le code du controlleur ne se compose que de PHP.